### PR TITLE
feat/#2: 루트 디렉토리 참조, .tf 없는 폴더는 실행 X

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,9 +67,19 @@ jobs:
             if [ "$VALUE" = "true" ]; then
               BASE_DIR="${KEY}-team-account"
 
+              # 루트 디렉터리 검사
+              TF_COUNT_ROOT=$(find "$BASE_DIR" -maxdepth 1 -name '*.tf' | wc -l)
+              if [ "$TF_COUNT_ROOT" -gt 0 ]; then
+                MATRIX_ITEMS+=("{\"dir\":\"$BASE_DIR\",\"role_key\":\"${ROLE_MAP[$KEY]}\"}")
+              fi
+
+              # 하위 디렉터리 검사
               for DIR in $(find $BASE_DIR -type d -mindepth 1); do
-                if [[ "$DIR" != *".terraform"* ]]; then
-                  MATRIX_ITEMS+=("{\"dir\":\"$DIR\",\"role_key\":\"${ROLE_MAP[$KEY]}\"}")
+                if [[ "$DIR" != *".terraform"* && "$DIR" != "$BASE_DIR/modules" ]]; then
+                  TF_COUNT=$(find "$DIR" -maxdepth 1 -name '*.tf' | wc -l)
+                  if [ "$TF_COUNT" -gt 0 ]; then
+                    MATRIX_ITEMS+=("{\"dir\":\"$DIR\",\"role_key\":\"${ROLE_MAP[$KEY]}\"}")
+                  fi
                 fi
               done
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Application CI
+name: Application-Deployment CI
 
 on:
   pull_request:
@@ -7,7 +7,10 @@ on:
       - "operation-team-account/**"
       - "identity-team-account/**"
       - "prod-team-account/**"
-
+      - "dev-team-account/**"
+      - "security-team-account/**"
+      - "stage-team-account/**"
+      - "management-team-account/**"
 
 permissions:
   contents: read
@@ -35,7 +38,7 @@ jobs:
           echo "Changed files:"
           echo "$FILES"
 
-          declare -A ROLE_MAP=(
+          declare -A ROLE_MAP=( 
             ["operation-team-account"]="ROLE_ARN_OPERATION"
             ["identity-team-account"]="ROLE_ARN_IDENTITY"
             ["prod-team-account"]="ROLE_ARN_PROD"
@@ -48,13 +51,24 @@ jobs:
           TMP_FILE=$(mktemp)
 
           for FILE in $FILES; do
-            # ex) identity-team-account/S3/main.tf
             DIR=$(dirname "$FILE")
             TOP_DIR=$(echo $DIR | cut -d/ -f1)
             ROLE_KEY="${ROLE_MAP[$TOP_DIR]}"
 
             if [ -n "$ROLE_KEY" ]; then
-              echo "$DIR|$ROLE_KEY" >> $TMP_FILE
+              # 루트 디렉터리
+              if [ "$DIR" == "$TOP_DIR" ]; then
+                TF_COUNT=$(find "$DIR" -maxdepth 1 -name '*.tf' | wc -l)
+                if [ "$TF_COUNT" -gt 0 ]; then
+                  echo "$DIR|$ROLE_KEY" >> $TMP_FILE
+                fi
+              else
+                # 하위 디렉터리
+                TF_COUNT=$(find "$DIR" -maxdepth 1 -name '*.tf' | wc -l)
+                if [ "$TF_COUNT" -gt 0 ]; then
+                  echo "$DIR|$ROLE_KEY" >> $TMP_FILE
+                fi
+              fi
             fi
           done
 


### PR DESCRIPTION
## #️⃣ Related Issues

> e.g. feat/#2

## 📝 Work Summary

- .tf 파일 없는 빈 폴더는 실행 제외하도록 Workflow 수정

- 루트 디렉터리(*-team-account/)도 .tf 존재 시 apply/CI 대상에 포함

### Screenshot (Optional)

## 💬 Review Notes (Optional)

> Add any specific points you would like the reviewers to focus on.