### PR TITLE
[Refactor] WAF 서비스 분리

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,8 +65,9 @@ jobs:
             ["prod-team-account/vpc"]=""
             ["prod-team-account/iam"]=""
             ["prod-team-account/acm"]=""
+            ["prod-team-account/waf"]=""
             ["operation-team-account/ecr"]="prod-team-account/deploy/iam"
-            ["prod-team-account/alb"]="prod-team-account/deploy/vpc prod-team-account/deploy/acm"
+            ["prod-team-account/alb"]="prod-team-account/deploy/vpc prod-team-account/deploy/acm prod-team-account/deploy/waf"
             ["prod-team-account/ecs"]="prod-team-account/deploy/vpc prod-team-account/deploy/iam prod-team-account/deploy/alb operation-team-account/deploy/ecr"
             ["prod-team-account/codedeploy"]="prod-team-account/deploy/ecs"
           )

--- a/prod-team-account/deploy/waf/backend.tf
+++ b/prod-team-account/deploy/waf/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "cloudfence-prod-state"
+    key            = "deploy/waf.tfstate"
+    region         = "ap-northeast-2"
+    dynamodb_table = "s3-prod-lock"
+    encrypt        = true
+  }
+}

--- a/prod-team-account/deploy/waf/main.tf
+++ b/prod-team-account/deploy/waf/main.tf
@@ -1,0 +1,53 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+}
+
+provider "aws" {
+  region = "ap-northeast-2"
+}
+
+# WAF
+resource "aws_wafv2_web_acl" "alb_waf" {
+  name        = "${var.project_name}-alb-waf"
+  description = "WAF for ALB"
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "waf-alb-metric"
+    sampled_requests_enabled   = true
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesCommonRuleSet"
+    priority = 1
+    override_action {
+      none {}
+    }
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesCommonRuleSet"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-alb-waf"
+  }
+}

--- a/prod-team-account/deploy/waf/outputs.tf
+++ b/prod-team-account/deploy/waf/outputs.tf
@@ -1,0 +1,4 @@
+output "web_acl_arn" {
+  description = "The ARN of the WAF Web ACL"
+  value       = aws_wafv2_web_acl.alb_waf.arn
+}

--- a/prod-team-account/deploy/waf/variables.tf
+++ b/prod-team-account/deploy/waf/variables.tf
@@ -1,0 +1,5 @@
+variable "project_name" {
+  description = "The name of the project"
+  type        = string
+  default     = "cloudfence"
+}


### PR DESCRIPTION
## #️⃣ Related Issues

#36 

## 📝 Work Summary

ALB 내에서 한번에 관리하는 WAF를 WAF 룰셋 관리 및 유지보수 용이성을 위해 서비스를 분리.
tfstate 관리를 위한 S3 구조 반영.

