### PR TITLE
Feat/#37: WAF 로그 전송 환경 구축

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,28 +157,40 @@ jobs:
           PLAN_TXT=plan.txt
           PLAN_JSON=plan.json
 
-          # Run terraform plan
-          terraform plan -no-color -out=$PLAN_FILE > /dev/null 2> plan_error.txt || echo "PLAN_FAILED=true" >> $GITHUB_ENV
+          if terraform plan -no-color -out=$PLAN_FILE > /dev/null 2> plan_error.txt; then
+            echo "PLAN_FAILED=false" >> $GITHUB_ENV
+            terraform show -no-color $PLAN_FILE > $PLAN_TXT
+            terraform show -json $PLAN_FILE > $PLAN_JSON || true
+          else
+            echo "PLAN_FAILED=true" >> $GITHUB_ENV
+            echo "Plan failed" > $PLAN_TXT
+            echo "{}" > $PLAN_JSON
+          fi
 
-          # Show plan text output
-          terraform show -no-color $PLAN_FILE > $PLAN_TXT 2>/dev/null || echo "Plan failed" > $PLAN_TXT
+          # 디버깅용 출력
+          echo "::group::Raw terraform show output"
+          cat $PLAN_TXT || echo "(empty)"
+          echo "::endgroup::"
 
-          # Remove ANSI color codes
-          cat $PLAN_TXT | \
-            sed 's/`/\\`/g' | \
-            tr -d '\r' | \
-            sed -r "s/\x1B\[[0-9;]*[JKmsu]//g" \
-            > cleaned_plan.txt
+          sed 's/`/\\`/g' $PLAN_TXT | tr -d '\r' | sed -r "s/\x1B\[[0-9;]*[JKmsu]//g" > cleaned_plan.txt
 
           PLAN_CONTENT=$(cat cleaned_plan.txt)
+          PLAN_ERROR=$(cat plan_error.txt || echo "No error captured")
 
-          # Save JSON plan for infracost
-          terraform show -json $PLAN_FILE > $PLAN_JSON || true
+          if [ -z "$PLAN_CONTENT" ]; then
+            PLAN_CONTENT="(no changes or output empty)"
+          fi
 
-          # Output plan content for PR comment
+          if [ -z "$PLAN_ERROR" ]; then
+            PLAN_ERROR="(no errors)"
+          fi
+
           {
             echo "PLAN_CONTENT<<EOF"
             echo "$PLAN_CONTENT"
+            echo "EOF"
+            echo "PLAN_ERROR<<EOF"
+            echo "$PLAN_ERROR"
             echo "EOF"
           } >> $GITHUB_OUTPUT
         working-directory: ${{ matrix.dir }}
@@ -201,6 +213,11 @@ jobs:
             ### Plan Output
             ```hcl
             ${{ steps.plan.outputs.PLAN_CONTENT }}
+            ```
+
+            ### Plan Error (if any)
+            ```
+            ${{ steps.plan.outputs.PLAN_ERROR }}
             ```
 
       - name: Setup Infracost

--- a/prod-team-account/deploy/waf/main.tf
+++ b/prod-team-account/deploy/waf/main.tf
@@ -130,7 +130,7 @@ resource "aws_wafv2_web_acl_logging_configuration" "waf_logging" {
     default_behavior = "DROP"
     filter {
       behavior    = "KEEP"
-      requirement = "MEET_ANY"
+      requirement = "MEETS_ANY"
       condition {
         action_condition {
           action = "BLOCK"

--- a/prod-team-account/deploy/waf/main.tf
+++ b/prod-team-account/deploy/waf/main.tf
@@ -129,7 +129,7 @@ resource "aws_wafv2_web_acl_logging_configuration" "waf_logging" {
   logging_filter {
     default_behavior = "DROP"
     filter {
-      behavior = "KEEP"
+      behavior    = "KEEP"
       requirement = "MEET_ANY"
       condition {
         action_condition {

--- a/prod-team-account/deploy/waf/main.tf
+++ b/prod-team-account/deploy/waf/main.tf
@@ -118,3 +118,10 @@ resource "aws_wafv2_web_acl" "alb_waf" {
     Name = "${var.project_name}-alb-waf"
   }
 }
+
+# S3로 로그 전송하도록 설정
+resource "aws_wafv2_web_acl_logging_configuration" "waf_logging" {
+  resource_arn            = aws_wafv2_web_acl.alb_waf.arn
+  log_destination_configs = ["arn:aws:s3:::whs-aws-logs"]
+}
+

--- a/prod-team-account/deploy/waf/main.tf
+++ b/prod-team-account/deploy/waf/main.tf
@@ -12,6 +12,51 @@ provider "aws" {
   region = "ap-northeast-2"
 }
 
+# rule 목록 정의
+locals {
+  managed_rules = {
+    # 규칙이름 = { 우선순위, AWS 관리형 규칙 이름 }
+    "CommonRuleSet"      = { priority = 10, name = "AWSManagedRulesCommonRuleSet" }
+    "KnownBadInputs"     = { priority = 20, name = "AWSManagedRulesKnownBadInputsRuleSet" }
+    "SQLiRuleSet"        = { priority = 30, name = "AWSManagedRulesSQLiRuleSet" }
+    "AmazonIpReputation" = { priority = 40, name = "AWSManagedRulesAmazonIpReputationList" }
+  }
+}
+
+# IP 기반 요청 제한 규칙 생성
+resource "aws_wafv2_rule_group" "rate_limit_rule" {
+  name        = "${var.project_name}-rate-limit-rule"
+  scope       = "REGIONAL"
+  capacity    = 50 
+  rule {
+    name     = "RateLimit5Min2000"
+    priority = 10
+
+    action {
+      block {} 
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 2000
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimitMetric"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.project_name}-rate-limit-metric"
+    sampled_requests_enabled   = true
+  }
+}
+
 # WAF
 resource "aws_wafv2_web_acl" "alb_waf" {
   name        = "${var.project_name}-alb-waf"
@@ -22,29 +67,51 @@ resource "aws_wafv2_web_acl" "alb_waf" {
     allow {}
   }
 
+  dynamic "rule" {
+    for_each = local.managed_rules
+    content {
+      name     = "AWS-${rule.value.name}"
+      priority = rule.value.priority
+
+      override_action {
+        none {}
+      }
+
+      statement {
+        managed_rule_group_statement {
+          vendor_name = "AWS"
+          name        = rule.value.name
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "waf-${rule.value.name}-metric"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  # 생성된 규칙을 사용하여 요청 제한 규칙 추가
+  rule{
+    name     = "RateLimitRule"
+    priority = 50
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      rule_group_reference_statement {
+        arn = aws_wafv2_rule_group.rate_limit_rule.arn
+      }
+    }
+  }
+
   visibility_config {
     cloudwatch_metrics_enabled = true
     metric_name                = "waf-alb-metric"
     sampled_requests_enabled   = true
-  }
-
-  rule {
-    name     = "AWS-AWSManagedRulesCommonRuleSet"
-    priority = 1
-    override_action {
-      none {}
-    }
-    statement {
-      managed_rule_group_statement {
-        vendor_name = "AWS"
-        name        = "AWSManagedRulesCommonRuleSet"
-      }
-    }
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "AWSManagedRulesCommonRuleSet"
-      sampled_requests_enabled   = true
-    }
   }
 
   tags = {

--- a/prod-team-account/deploy/waf/main.tf
+++ b/prod-team-account/deploy/waf/main.tf
@@ -130,6 +130,7 @@ resource "aws_wafv2_web_acl_logging_configuration" "waf_logging" {
     default_behavior = "DROP"
     filter {
       behavior = "KEEP"
+      requirement = "MEET_ANY"
       condition {
         action_condition {
           action = "BLOCK"

--- a/prod-team-account/deploy/waf/variables.tf
+++ b/prod-team-account/deploy/waf/variables.tf
@@ -3,3 +3,9 @@ variable "project_name" {
   type        = string
   default     = "cloudfence"
 }
+
+variable "bucket_name" {
+  description = "The name of the S3 bucket for WAF logs"
+  type        = string
+
+}


### PR DESCRIPTION
## #️⃣ Related Issues

#37 

## 📝 Work Summary

prod-team-account의 WAF에서 생성된 로그를 operation-team-account의 S3버킷으로 전송하도록 구성.
보안 관련 로그를 한 곳에서 수집하고 관리하여 중앙 집중식 로깅 시스템 구축.
Rule Set에 위배되어 block 상태인 트래픽 로그를 전송하도록 설정.